### PR TITLE
Fixed SubmitForm test

### DIFF
--- a/react-website/src/tests/SubmitForm.test.js
+++ b/react-website/src/tests/SubmitForm.test.js
@@ -18,7 +18,7 @@ test('Button test', () => {
 
     const submitButton = screen.getByTestId('submitButton');
     expect(submitButton).toBeInTheDocument();
-    expect(submitButton).toHaveTextContent('submitButton');
+    expect(submitButton).toHaveTextContent('Submit Online');
     expect(submitButton).toContainHTML('</Link>');
 
 });


### PR DESCRIPTION
Fix to SubmitForm (homepage) test. The test, after these changes, should now properly check if the navigation (to form) button contains the text "Submit Online".