### PR TITLE
Reverted message requirement in mongo schema

### DIFF
--- a/server/models/FormPost.js
+++ b/server/models/FormPost.js
@@ -21,7 +21,7 @@ const FormPostSchema = new Schema({
     },
     message: {
         type: String,
-        required: true
+        required: false
     }
 });
 


### PR DESCRIPTION
- message is not a required field of the form
- mistake was made in commit 974a9789daf57eec748d36fcc5d4431ff704defa